### PR TITLE
add Syntax-F# - link to ionide suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Language packages extend the editor with syntax highlighting and/or snippets for
 
 - [Dockerfile](https://marketplace.visualstudio.com/items?itemName=PeterJausovec.vscode-docker)
 - [Elixir](https://marketplace.visualstudio.com/items?itemName=mjmcloug.vscode-elixir)
+- [F#](https://marketplace.visualstudio.com/items?itemName=Ionide.Ionide-fsharp)
 - [React JSX](https://marketplace.visualstudio.com/items?itemName=TwentyChung.jsx)
 - [Stylus](https://marketplace.visualstudio.com/items?itemName=buzinas.stylus)
 


### PR DESCRIPTION
[Ionide](ionide.io) is a bunch of VS Code plugins. Adds an awesome support for an awesome F# language and tools: FAKE and PAKET (installed separately)