### PR TITLE
Fix C++ link in Table of Contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A curated list of delightful VS Code packages and resources. For more awesomenes
 
 - [Syntax](#syntax)
 - [Lint and IntelliSense](#lint-and-intellisense)
- - [C++](#c++)
+ - [C++](#c)
  - [CSS](#css)
  - [Go](#go)
  - [JavaScript](#javascript)


### PR DESCRIPTION
The original C++ link points to "#c++" which is incorrect (It should be "#c").

It seems that plus signs are removed during parsing.