### PR TITLE
Add SVG viewer and fix ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ A curated list of delightful [Visual Studio Code](https://code.visualstudio.com/
  - [Runner](#runner)
  - [SVG Viewer](#svg-viewer)
  - [Slack](#slack)
+ - [Vim Mode](#vim-mode)
 - [Resources for extension developers](#resources-for-extension-developers)
  - [Documentation](#documentation)
  - [Libraries](#libraries)
@@ -342,18 +343,17 @@ However, this extension allow you to do it by patching VS code, until it's imple
 
 ![SVG Viewer](https://github.com/cssho/vscode-svgviewer/blob/master/img/preview.png)
 
-### [Vim Mode](https://marketplace.visualstudio.com/items?itemName=vscodevim.vim)
-
-> Relatively new, but promising extension implementing Vim features in VSCode. Authors suggest to join their [Slack channel](https://vscodevim-slackin.azurewebsites.net/) for feature requests on your favorite Vim features
-
-![](https://github.com/VSCodeVim/Vim/raw/master/images/screen.png)
-
 ### [Slack](https://marketplace.visualstudio.com/items?itemName=sozercan.slack)
 
 > Send messages and code snippets, upload files to Slack
 
 ![](https://raw.githubusercontent.com/sozercan/vscode-slack/master/slack-upload.gif)
 
+### [Vim Mode](https://marketplace.visualstudio.com/items?itemName=vscodevim.vim)
+
+> Relatively new, but promising extension implementing Vim features in VSCode. Authors suggest to join their [Slack channel](https://vscodevim-slackin.azurewebsites.net/) for feature requests on your favorite Vim features
+
+![](https://github.com/VSCodeVim/Vim/raw/master/images/screen.png)
 
 ## Resources for extension developers
 

--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ A curated list of delightful [Visual Studio Code](https://code.visualstudio.com/
  - [Editor Config for VS Code](#editor-config-for-vs-code)
  - [ftp-sync](#ftp-sync)
  - [Runner](#runner)
- - [SVG Viewer](#svg-viewer)
  - [Slack](#slack)
+ - [SVG Viewer](#svg-viewer)
  - [Vim Mode](#vim-mode)
 - [Resources for extension developers](#resources-for-extension-developers)
  - [Documentation](#documentation)
@@ -337,17 +337,17 @@ However, this extension allow you to do it by patching VS code, until it's imple
 
 ![](https://raw.githubusercontent.com/mattn/vscode-runner/master/images/screenshot.gif)
 
-#### [SVG Viewer](https://marketplace.visualstudio.com/items?itemName=cssho.vscode-svgviewer)
-
-> View an SVG in the editor and export it as data URI scheme or PNG.
-
-![SVG Viewer](https://github.com/cssho/vscode-svgviewer/blob/master/img/preview.png)
-
 ### [Slack](https://marketplace.visualstudio.com/items?itemName=sozercan.slack)
 
 > Send messages and code snippets, upload files to Slack
 
 ![](https://raw.githubusercontent.com/sozercan/vscode-slack/master/slack-upload.gif)
+
+### [SVG Viewer](https://marketplace.visualstudio.com/items?itemName=cssho.vscode-svgviewer)
+
+> View an SVG in the editor and export it as data URI scheme or PNG.
+
+![SVG Viewer](https://github.com/cssho/vscode-svgviewer/blob/master/img/preview.png)
 
 ### [Vim Mode](https://marketplace.visualstudio.com/items?itemName=vscodevim.vim)
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ A curated list of delightful [Visual Studio Code](https://code.visualstudio.com/
  - [Editor Config for VS Code](#editor-config-for-vs-code)
  - [ftp-sync](#ftp-sync)
  - [Runner](#runner)
+ - [SVG Viewer](#svg-viewer)
  - [Slack](#slack)
 - [Resources for extension developers](#resources-for-extension-developers)
  - [Documentation](#documentation)
@@ -334,6 +335,12 @@ However, this extension allow you to do it by patching VS code, until it's imple
 > Run various scripts right from VS Code
 
 ![](https://raw.githubusercontent.com/mattn/vscode-runner/master/images/screenshot.gif)
+
+#### [SVG Viewer](https://marketplace.visualstudio.com/items?itemName=cssho.vscode-svgviewer)
+
+> View an SVG in the editor and export it as data URI scheme or PNG.
+
+![SVG Viewer](https://github.com/cssho/vscode-svgviewer/blob/master/img/preview.png)
 
 ### [Vim Mode](https://marketplace.visualstudio.com/items?itemName=vscodevim.vim)
 


### PR DESCRIPTION
While adding the extension, I noticed that the alphabetical ordering was off and Vim Mode was missing from the table of contents, so I fixed this as well.

It also seems that the Vim Mode image is currently broken (couldn't find an alternative one in the repo either).