### PR TITLE
added Remote Workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ A curated list of delightful [Visual Studio Code](https://code.visualstudio.com/
   - [ftp-sync](#ftp-sync)
   - [PlatformIO](#platformio)
   - [Quokka](#quokka)
+  - [Remote Workspace](#remote-workspace)
   - [Runner](#runner)
   - [Slack](#slack)
   - [Spotify](#spotify)
@@ -610,6 +611,12 @@ To enable Emmet support in .twig files, you'll need to have the following in you
 > Rapid prototyping playground for JavaScript and TypeScript in VS Code, with access to your project's files, inline reporting, code coverage and rich output formatting.
 
 ![](https://quokkajs.com/assets/img/vsc1.gif)
+
+## [Remote Workspace](https://marketplace.visualstudio.com/items?itemName=mkloubert.vscode-remote-workspace)
+
+> Multi protocol support for things, like Azure blobs, S3 buckets, Dropbox, (S)FTP or WebDAV files, by using new [FileSystem API](https://code.visualstudio.com/docs/extensionAPI/vscode-api#FileSystemProvider), especially for accessing resources like local files and folders in the editor as [workspace folders](https://code.visualstudio.com/docs/editor/multi-root-workspaces).
+
+![](https://raw.githubusercontent.com/mkloubert/vscode-remote-workspace/master/img/demo1.gif)
 
 ## [Runner](https://marketplace.visualstudio.com/items?itemName=mattn.Runner)
 


### PR DESCRIPTION
## vscode-remote-workspace

![](https://raw.githubusercontent.com/mkloubert/vscode-remote-workspace/master/img/demo1.gif)

Multi protocol support for things, like Azure blobs, S3 buckets, Dropbox, (S)FTP or WebDAV files, by using new [FileSystem API](https://code.visualstudio.com/docs/extensionAPI/vscode-api#FileSystemProvider), especially for accessing resources like local files and folders in the editor as [workspace folders](https://code.visualstudio.com/docs/editor/multi-root-workspaces).

## Why do you think this extension is awesome?

You can add one or more remote folders by a simple and powerful URI configuration as [workspace folders](https://code.visualstudio.com/docs/editor/multi-root-workspaces).

The extension supports:

* AWS S3 buckets
* Azure blobs
* Dropbox
* FTP(s)
* SFTP
* Slack
* WebDAV

Example for accessing a S3 bucket, by creating (or editing) and opening a `*.code-workspace` file:

```json
{
    "folders": [{
        "uri": "s3://my-bucket/?acl=public-read",
        "name": "My S3 Bucket"
    }]
}
```

## Make sure that:

[x] Screenshot/GIF included (to demonstrate the plugin functionality)

[x] ToC updated
