### PR TITLE
adding extension to support Hive SQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ Language packages extend the editor with syntax highlighting and/or snippets for
 - [Fortran](https://marketplace.visualstudio.com/items?itemName=Gimly81.fortran)
 - [Hack(HHVM)](https://marketplace.visualstudio.com/items?itemName=pranayagarwal.vscode-hack)
 - [Handlebars](https://marketplace.visualstudio.com/items?itemName=andrejunges.Handlebars)
+- [Hive SQL](https://marketplace.visualstudio.com/items?itemName=josephtbradley.hive-sql)
 - [KL](https://marketplace.visualstudio.com/items?itemName=melmass.kl)
 - [Kotlin](https://marketplace.visualstudio.com/items?itemName=mathiasfrohlich.Kotlin)
 - [LaTeX](https://marketplace.visualstudio.com/items?itemName=torn4dom4n.latex-support)


### PR DESCRIPTION
## Name of an extension you are adding
Hive-SQL
...

## Why do you think this extension is awesome?
This extension provides syntax highlighting and formatting for Hive SQL.
...

## Make sure that:

[ ] Screenshot/GIF included (to demonstrate the plugin functionality)
Not provided, to maintain consistency with other "Syntax" entries.

[ ] ToC updated
n/a