### PR TITLE
Adding highlight-matching-tag to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ A curated list of delightful [Visual Studio Code](https://code.visualstudio.com/
   - [Edit with Shell Command](#edit-with-shell-command)
   - [Editor Config for VS Code](#editor-config-for-vs-code)
   - [ftp-sync](#ftp-sync)
+  - [Highlight JSX/HTML tags](#highlight-matching-tag)
   - [PlatformIO](#platformio)
   - [Quokka](#quokka)
   - [Remote Workspace](#remote-workspace)
@@ -640,6 +641,12 @@ To enable Emmet support in .twig files, you'll need to have the following in you
 > Auto-sync your work to remote FTP server
 
 ![](https://i.imgur.com/W9h4pwW.gif)
+
+## [Highlight JSX/HTML tags](https://marketplace.visualstudio.com/items?itemName=vincaslt.highlight-matching-tag)
+
+> Highlights matching tags in the file.
+
+![](https://camo.githubusercontent.com/010b886fb93f49c56e4c7308ba0a5a1aca8a2db7/68747470733a2f2f692e696d67626f782e636f6d2f4455584c467657372e676966)
 
 ## [PlatformIO](https://marketplace.visualstudio.com/items?itemName=formulahendry.platformio)
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ A curated list of delightful [Visual Studio Code](https://code.visualstudio.com/
   - [Edit with Shell Command](#edit-with-shell-command)
   - [Editor Config for VS Code](#editor-config-for-vs-code)
   - [ftp-sync](#ftp-sync)
-  - [Highlight JSX/HTML tags](#highlight-jsx/html-tags)
+  - [Highlight JSX/HTML tags](#highlight-jsxhtml-tags)
   - [PlatformIO](#platformio)
   - [Quokka](#quokka)
   - [Remote Workspace](#remote-workspace)

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ A curated list of delightful [Visual Studio Code](https://code.visualstudio.com/
   - [Edit with Shell Command](#edit-with-shell-command)
   - [Editor Config for VS Code](#editor-config-for-vs-code)
   - [ftp-sync](#ftp-sync)
-  - [Highlight JSX/HTML tags](#highlight-matching-tag)
+  - [Highlight JSX/HTML tags](#highlight-jsx/html-tags)
   - [PlatformIO](#platformio)
   - [Quokka](#quokka)
   - [Remote Workspace](#remote-workspace)


### PR DESCRIPTION
## Name of an extension you are adding
[highlight-matching-tag](https://marketplace.visualstudio.com/items?itemName=vincaslt.highlight-matching-tag)
...

## Why do you think this extension is awesome?
![](https://camo.githubusercontent.com/010b886fb93f49c56e4c7308ba0a5a1aca8a2db7/68747470733a2f2f692e696d67626f782e636f6d2f4455584c467657372e676966)

This was one of the missing features when migrating from WebStorm.
...

## Make sure that:

[x] Screenshot/GIF included (to demonstrate the plugin functionality)

[x] ToC updated
