### PR TITLE
Added link for flatbuffers syntax highlighter

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ Language packages extend the editor with syntax highlighting and/or snippets for
 - [Elm](https://marketplace.visualstudio.com/items?itemName=sbrink.elm)
 - [Erlang](https://marketplace.visualstudio.com/items?itemName=pgourlain.erlang)
 - [F#](https://marketplace.visualstudio.com/items?itemName=Ionide.Ionide-fsharp)
+- [Flatbuffers](https://marketplace.visualstudio.com/items?itemName=gaborv.flatbuffers)
 - [Fortran](https://marketplace.visualstudio.com/items?itemName=Gimly81.fortran)
 - [Hack(HHVM)](https://marketplace.visualstudio.com/items?itemName=pranayagarwal.vscode-hack)
 - [Handlebars](https://marketplace.visualstudio.com/items?itemName=andrejunges.Handlebars)


### PR DESCRIPTION
flatbuffers idl
https://google.github.io/flatbuffers/flatbuffers_grammar.html

## Name of an extension you are adding

flatbuffers syntax highlighter.

## Why do you think this extension is awesome?

makes it easy to write the flatbuffers based schema in visual studio code.


