### PR TITLE
Adding list of people to follow related to @code

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A curated list of delightful [Visual Studio Code](https://code.visualstudio.com/
 # Table of Contents
 
 - [Official](#official)
-- [People to Follow](#people-to-follow)
+- [Syntax](#syntax)
 - [Migrating from other editors](#migrating-from-other-editors)
   - [Migrating from Vim](#migrating-from-vim)
   - [Migrating from Atom](#migrating-from-atom)
@@ -131,7 +131,7 @@ A curated list of delightful [Visual Studio Code](https://code.visualstudio.com/
   - [Plastic by Will Stone](#plastic-by-will-stone)
   - [Nord by arcticicestudio](#nord-by-arcticicestudio)
   - [Shades of Purple by Ahmad Awais](#shades-of-purple-by-ahmad-awais)
-- [Syntax](#syntax)
+- [People to Follow](#people-to-follow)
 - [Resources for extension developers](#resources-for-extension-developers)
   - [Documentation](#documentation)
   - [Libraries](#libraries)

--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ A curated list of delightful [Visual Studio Code](https://code.visualstudio.com/
 
 - [Official](#official)
 - [People to Follow](#people-to-follow)
-- [Syntax](#syntax)
 - [Migrating from other editors](#migrating-from-other-editors)
   - [Migrating from Vim](#migrating-from-vim)
   - [Migrating from Atom](#migrating-from-atom)
@@ -132,6 +131,7 @@ A curated list of delightful [Visual Studio Code](https://code.visualstudio.com/
   - [Plastic by Will Stone](#plastic-by-will-stone)
   - [Nord by arcticicestudio](#nord-by-arcticicestudio)
   - [Shades of Purple by Ahmad Awais](#shades-of-purple-by-ahmad-awais)
+- [Syntax](#syntax)
 - [Resources for extension developers](#resources-for-extension-developers)
   - [Documentation](#documentation)
   - [Libraries](#libraries)
@@ -146,27 +146,6 @@ A curated list of delightful [Visual Studio Code](https://code.visualstudio.com/
 - [Releases (stable channel)](https://code.visualstudio.com/download)
 - [Releases (insiders channel)](https://code.visualstudio.com/insiders)
 - [Monthly iteration plans](https://github.com/Microsoft/vscode/issues?utf8=%E2%9C%93&q=label%3Aiteration-plan+)
-
-# People to Follow
-
-A list of Twitter accounts for various people in the VS Code Community
-
-- [@code](https://twitter.com/code) - The official VS Code Twitter
-- [@auchenberg](https://twitter.com/auchenberg) - VS Code Program Manager
-- [@BenjaminPasero](https://twitter.com/BenjaminPasero) - VS Code Dev
-- [@chrisdias](https://twitter.com/chrisdias) - VS Code Program Manager
-- [@_clarkio](https://twitter.com/_clarkio) - Developer Advocate @ Azure. Creator of VS Code release highlight videos
-- [@eamodio](https://twitter.com/eamodio) - GitLens creator
-- [@ErichGamma](https://twitter.com/ErichGamma) - VS Code Dev
-- [@IsidorN](https://twitter.com/@IsidorN) - VS Code Dev
-- [@joaomoreno](https://twitter.com/joaomoreno) - VS Code Dev
-- [@johannesrieken](https://twitter.com/johannesrieken) - VS Code Dev
-- [@lannonbr](https://twitter.com/lannonbr) - Creator of vscode.rocks & JS Parameter Annotations extension
-- [@maeschli](https://twitter.com/maeschli) - VS Code Dev
-- [@mattbierner](https://twitter.com/code) - VS Code Dev
-- [@MrAhmadAwais](https://twitter.com/MrAhmadAwais) - Wordpress Core Dev. Creator of VSCode Pro course & Shades of Purple theme
-- [@ramyanexus](https://twitter.com/ramyanexus) - VS Code Dev. Maintainer of Go extension
-- [@Tyriar](https://twitter.com/Tyriar) - VS Code Dev. Creator of xterm.js
 
 # Syntax
 
@@ -913,6 +892,27 @@ An arctic, north-bluish clean and elegant Visual Studio Code theme.
 <a href="https://vscodethemes.com/e/ahmadawais.shades-of-purple">
   <img src="./themes/screenshots/ahmadawais.shades-of-purple.png" width="600" />
 </a>
+
+# People to Follow
+
+A list of Twitter accounts for various people in the VS Code Community
+
+- [@code](https://twitter.com/code) - The official VS Code Twitter
+- [@auchenberg](https://twitter.com/auchenberg) - VS Code Program Manager
+- [@BenjaminPasero](https://twitter.com/BenjaminPasero) - VS Code Dev
+- [@chrisdias](https://twitter.com/chrisdias) - VS Code Program Manager
+- [@_clarkio](https://twitter.com/_clarkio) - Developer Advocate @ Azure. Creator of VS Code release highlight videos
+- [@eamodio](https://twitter.com/eamodio) - GitLens creator
+- [@ErichGamma](https://twitter.com/ErichGamma) - VS Code Dev
+- [@IsidorN](https://twitter.com/@IsidorN) - VS Code Dev
+- [@joaomoreno](https://twitter.com/joaomoreno) - VS Code Dev
+- [@johannesrieken](https://twitter.com/johannesrieken) - VS Code Dev
+- [@lannonbr](https://twitter.com/lannonbr) - Creator of vscode.rocks & JS Parameter Annotations extension
+- [@maeschli](https://twitter.com/maeschli) - VS Code Dev
+- [@mattbierner](https://twitter.com/code) - VS Code Dev
+- [@MrAhmadAwais](https://twitter.com/MrAhmadAwais) - Wordpress Core Dev. Creator of VSCode Pro course & Shades of Purple theme
+- [@ramyanexus](https://twitter.com/ramyanexus) - VS Code Dev. Maintainer of Go extension
+- [@Tyriar](https://twitter.com/Tyriar) - VS Code Dev. Creator of xterm.js
 
 # Resources for extension developers
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ A curated list of delightful [Visual Studio Code](https://code.visualstudio.com/
 # Table of Contents
 
 - [Official](#official)
+- [People to Follow](#people-to-follow)
 - [Syntax](#syntax)
 - [Migrating from other editors](#migrating-from-other-editors)
   - [Migrating from Vim](#migrating-from-vim)
@@ -145,6 +146,27 @@ A curated list of delightful [Visual Studio Code](https://code.visualstudio.com/
 - [Releases (stable channel)](https://code.visualstudio.com/download)
 - [Releases (insiders channel)](https://code.visualstudio.com/insiders)
 - [Monthly iteration plans](https://github.com/Microsoft/vscode/issues?utf8=%E2%9C%93&q=label%3Aiteration-plan+)
+
+# People to Follow
+
+A list of Twitter accounts for various people in the VS Code Community
+
+- [@code](https://twitter.com/code) - The official VS Code Twitter
+- [@auchenberg](https://twitter.com/auchenberg) - VS Code Program Manager
+- [@BenjaminPasero](https://twitter.com/BenjaminPasero) - VS Code Dev
+- [@chrisdias](https://twitter.com/chrisdias) - VS Code Program Manager
+- [@_clarkio](https://twitter.com/_clarkio) - Developer Advocate @ Azure. Creator of VS Code release highlight videos
+- [@eamodio](https://twitter.com/eamodio) - GitLens creator
+- [@ErichGamma](https://twitter.com/ErichGamma) - VS Code Dev
+- [@IsidorN](https://twitter.com/@IsidorN) - VS Code Dev
+- [@joaomoreno](https://twitter.com/joaomoreno) - VS Code Dev
+- [@johannesrieken](https://twitter.com/johannesrieken) - VS Code Dev
+- [@lannonbr](https://twitter.com/lannonbr) - Creator of vscode.rocks & JS Parameter Annotations extension
+- [@maeschli](https://twitter.com/maeschli) - VS Code Dev
+- [@mattbierner](https://twitter.com/code) - VS Code Dev
+- [@MrAhmadAwais](https://twitter.com/MrAhmadAwais) - Wordpress Core Dev. Creator of VSCode Pro course & Shades of Purple theme
+- [@ramyanexus](https://twitter.com/ramyanexus) - VS Code Dev. Maintainer of Go extension
+- [@Tyriar](https://twitter.com/Tyriar) - VS Code Dev. Creator of xterm.js
 
 # Syntax
 


### PR DESCRIPTION
Closes #169.

I created a list of active people on Twitter that promote VS Code & the community. There are likely more people to add to it, but this is a good start.

Rather than merging it in directly I will have at least one other collaborator review it and merge it in.