### PR TITLE
Add Befunge to syntax list

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ A curated list of delightful [Visual Studio Code](https://code.visualstudio.com/
 Language packages extend the editor with syntax highlighting and/or snippets for a specific language or file format.
 
 - [Arduino](https://marketplace.visualstudio.com/items?itemName=vsciot-vscode.vscode-arduino)
+- [Befunge](https://marketplace.visualstudio.com/items?itemName=kagof.befunge)
 - [Blink](https://marketplace.visualstudio.com/items?itemName=melmass.blink)
 - [Bolt](https://marketplace.visualstudio.com/items?itemName=smkamranqadri.vscode-bolt-language)
 - [Bond](https://marketplace.visualstudio.com/items?itemName=vicey.vscode-bond)


### PR DESCRIPTION
## Name of an extension you are adding
Befunge

## Why do you think this extension is awesome?
Adds language support and alignment guides for the Befunge-93 and Funge-98 esolangs - alignment guides are quite helpful in a language which takes advantage of directionality

## Make sure that:

[ ] Screenshot/GIF included (to demonstrate the plugin functionality)
 - not included, as it doesn't look like any other language syntaxes included one. However, here is a screenshot:
![](https://raw.githubusercontent.com/kagof/VSCode-Befunge/master/assets/screenshots/screenshot-fizzbuzz.png)

[x] ToC updated
