### PR TITLE
🐛 FIX: lingo for the intro

### DIFF
--- a/README.md
+++ b/README.md
@@ -910,7 +910,7 @@ A list of Twitter accounts for various people in the VS Code Community
 - [@lannonbr](https://twitter.com/lannonbr) - Creator of vscode.rocks & JS Parameter Annotations extension
 - [@maeschli](https://twitter.com/maeschli) - VS Code Dev
 - [@mattbierner](https://twitter.com/code) - VS Code Dev
-- [@MrAhmadAwais](https://twitter.com/MrAhmadAwais) - Wordpress Core Dev. Creator of VSCode Pro course & Shades of Purple theme
+- [@MrAhmadAwais](https://twitter.com/MrAhmadAwais) - JS/WordPress Core Dev. Creator of VSCode.pro course & Shades of Purple theme
 - [@ramyanexus](https://twitter.com/ramyanexus) - VS Code Dev. Maintainer of Go extension
 - [@Tyriar](https://twitter.com/Tyriar) - VS Code Dev. Creator of xterm.js
 


### PR DESCRIPTION
Just fixing my intro, I preach writing the right names and my intro has `Wordpress` written in it instead of `WordPress` so I fixed the lingo and a couple other small changes in the same line.

Thanks for working on this. Gets more awesome every time I open :)

Peace! ✌️