### PR TITLE
Add Quick Require to JS Intellisense / Linting

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,9 @@ See the difference between these two [here](https://github.com/michaelgmcd/vscod
 - [XO](https://marketplace.visualstudio.com/items?itemName=samverschueren.linter-xo) - Linter for [XO](https://github.com/xojs/xo).
 - [AVA](https://marketplace.visualstudio.com/items?itemName=samverschueren.ava) - Snippets for [AVA](https://github.com/avajs/ava).
 - [Prettier](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) - Linter, Formatter and Pretty printer for [Prettier](https://github.com/prettier/prettier-vscode).
+- [Quick Require](https://marketplace.visualstudio.com/items?itemName=milkmidi.vs-code-quick-require) - Imports / Require javascript files available in your workspace using a relative path.
+![Quick Require importing local js files](https://raw.githubusercontent.com/milkmidi/vscode_extension_quick_require/master/img/screen.gif)
+
 
 ### [Debugger for Chrome](https://marketplace.visualstudio.com/items?itemName=msjsdiag.debugger-for-chrome)
 


### PR DESCRIPTION
## Name of the extension you are adding
Quick Require
...

## Why do you think this extension is awesome?
When building locally, you can quickly import files by name from folders away without counting on you fingers to see how many folder back you src folder is.
...

## Make sure that:

<!-- 
Check off the checkboxes with an 'x' like this: [x] 
-->

- [x] Screenshot/GIF included (to demonstrate the plugin functionality)

- [x] ToC updated
