### PR TITLE
Add MSBuild Project Tool extension to C# language section

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,10 @@ Unlike some other editors, VS Code supports IntelliSense, linting, outline out-o
 
 ![C# Extensions](https://raw.githubusercontent.com/jchannon/csharpextensions/master/featureimages/fullpropfromctor.gif)
 
+- [MSBuild Project Tools](https://marketplace.visualstudio.com/items?itemName=tintoy.msbuild-project-tools)
+
+![MSBuild Project Tools](https://github.com/tintoy/msbuild-project-tools-vscode/raw/master/docs/images/extension-in-action.gif)
+
 ## Clojure
 
 ### [Calva](https://marketplace.visualstudio.com/items?itemName=cospaia.clojure4vscode)

--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ Unlike some other editors, VS Code supports IntelliSense, linting, outline out-o
 
 - [MSBuild Project Tools](https://marketplace.visualstudio.com/items?itemName=tintoy.msbuild-project-tools)
 
-![MSBuild Project Tools](https://github.com/tintoy/msbuild-project-tools-vscode/raw/master/docs/images/extension-in-action.gif)
+![MSBuild Project Tools](https://raw.githubusercontent.com/tintoy/msbuild-project-tools-vscode/master/docs/images/extension-in-action.gif)
 
 ## Clojure
 


### PR DESCRIPTION
## Name of the extension you are adding

MS Build Project Tools

## Why do you think this extension is awesome?

MSBuild Project Intellisense Support via the Language Server Protocol, Intellisense for Nuget Packages

The second is the most common case, and in many cases beats out the Visual Studio IDE support for Nuget packages, as the lookup is faster, and more direct since you're changing the project file directly. I am sure the first case will be extremely helpful to many who forget the obscure and arcane MSBuild project file syntax due to the infrequency of having to modify them.

## Make sure that:

<!-- 
Check off the checkboxes with an 'x' like this: [x] 
-->

- [x] Screenshot/GIF included (to demonstrate the plugin functionality)

- [!] ToC updated

C# TOC already exists
