### PR TITLE
Add Format HTML in PHP extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,7 +348,7 @@ See the difference between these two [here](https://github.com/michaelgmcd/vscod
 ## TypeScript
 
 - [tslint](https://marketplace.visualstudio.com/items?itemName=eg2.tslint) - TSLint for Visual Studio Code
-- [TypeScript Hero](https://marketplace.visualstudio.com/items?itemName=rbbit.typescript-hero) - Code outline view of your open TS, sort and organize your imports. 
+- [TypeScript Hero](https://marketplace.visualstudio.com/items?itemName=rbbit.typescript-hero) - Code outline view of your open TS, sort and organize your imports.
 
 ## Markdown
 
@@ -405,6 +405,10 @@ To enable Emmet support in .twig files, you'll need to have the following in you
 ```
 
 ### Other extensions
+
+- [Format HTML in PHP](https://marketplace.visualstudio.com/items?itemName=rifi2k.format-html-in-php) - Formatting for the HTML in PHP files. Runs before the save action so you can still have a PHP formatter.
+
+![Format HTML in PHP](https://raw.githubusercontent.com/RiFi2k/format-html-in-php/master/format-html-in-php.gif)
 
 - [Composer](https://marketplace.visualstudio.com/items?itemName=ikappas.composer)
 - [PHP Debug](https://marketplace.visualstudio.com/items?itemName=felixfbecker.php-debug) - XDebug extension for Visual Studio Code


### PR DESCRIPTION
## Name of the extension you are adding

Format HTML in PHP

## Why do you think this extension is awesome?

If you quickly google "How do I format the HTML in PHP files?" you will find multiple VSCode github issues and Stackoverflow posts about this long standing issue. This extension fixes it while still allowing you to register a normal PHP formatting extension because it does the work onBeforeSave and also gives you a keybinding.

## Make sure that:

- [ X ] Screenshot/GIF included (to demonstrate the plugin functionality)

- [ ] ToC updated (Nested in a linked category)
