### PR TITLE
add ColorTabs extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ A curated list of delightful [Visual Studio Code](https://code.visualstudio.com/
   - [Azure Cosmos DB](#azure-cosmos-db)
   - [Azure IoT Toolkit](#azure-iot-toolkit)
   - [Bookmarks](#bookmarks)
+  - [Color Tabs](#color-tabs)
   - [Create tests](#create-tests)
   - [Deploy](#deploy)
   - [Duplicate Action](#duplicate-action)
@@ -470,6 +471,12 @@ To enable Emmet support in .twig files, you'll need to have the following in you
 ![Bookmarks command screenshot](https://raw.githubusercontent.com/alefragnani/vscode-bookmarks/master/images/bookmarks-commands.png)
 
 ![Bookmarks toogle screenshot](https://raw.githubusercontent.com/alefragnani/vscode-bookmarks/master/images/bookmarks-toggle.png)
+
+## [Color Tabs](https://marketplace.visualstudio.com/items?itemName=orepor.color-tabs-vscode-ext)
+
+> An extension for big projects or monorepos that colors your tab/titlebar based on the current package
+
+![Color your tabs and/or titlebar based on regex](https://raw.githubusercontent.com/oreporan/color-tabs-vscode/master/docs/example_gif.gif)
 
 ## [Create tests](https://marketplace.visualstudio.com/items?itemName=hardikmodha.create-tests)
 


### PR DESCRIPTION
## Name of the extension you are adding

ColorTabs

## Why do you think this extension is awesome?

One of the few extensions that target working in monorepos or big projects. It can:
1. Color your active tab
2. Color your titlebar
3. Add a custom label to your title bar

All based on a list of rules you provide, so for example, if you're working on a react+react-native project you can say

`*/mobile/*` -> `red`
`*/green/*` -> `green`


## Make sure that:

<!-- 
Check off the checkboxes with an 'x' like this: [x] 
-->

- [X] Screenshot/GIF included (to demonstrate the plugin functionality)

- [X] ToC updated
