### PR TITLE
Remove 404 link

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,7 +325,6 @@ Unlike some other editors, VS Code supports IntelliSense, linting, outline out-o
 
 ![CSS Peek](https://github.com/pranaygp/vscode-css-peek/blob/master/working.gif)
 
-- [stylelint](https://marketplace.visualstudio.com/items?itemName=shinnn.stylelint) - Lint CSS/SCSS.
 - [Autoprefixer](https://marketplace.visualstudio.com/items?itemName=mrmlnc.vscode-autoprefixer)
   Parse CSS,SCSS, LESS and add vendor prefixes automatically.
   ![Autoprefixer](https://cloud.githubusercontent.com/assets/7034281/16823311/da82a3c6-496b-11e6-8d95-0bebbf0b9607.gif)


### PR DESCRIPTION
Remove `shinnn.stylelint` link which causes the CI build failed.

It seems to have been abandoned: stylelint/stylelint#4438
