### PR TITLE
Add Wenyan Lang for VSCode

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ Language packages extend the editor with syntax highlighting and/or snippets for
 - [Stylus](https://marketplace.visualstudio.com/items?itemName=sysoev.language-stylus)
 - [Swift](https://marketplace.visualstudio.com/items?itemName=Kasik96.swift)
 - [VEX](https://marketplace.visualstudio.com/items?itemName=melmass.vex)
+- [Wenyan](https://github.com/antfu/wenyan-lang-vscode)
 - [Zephir](https://marketplace.visualstudio.com/items?itemName=zephir-lang.zephir)
 
 # Migrating from other editors


### PR DESCRIPTION
## Name of the extension you are adding

文言 Wenyan Lang

https://marketplace.visualstudio.com/items?itemName=antfu.wenyan-lang

## Why do you think this extension is awesome?

It's the only vscode out there that supports [Wenyan Lang](https://github.com/LingDong-/wenyan-lang), a programming language for the ancient Chinese which grows rapidly in recent weeks.

This extension supports syntax highlight, snippets, direct executing, compiling, rendering and more.

## Make sure that:

<!-- 
Check off the checkboxes with an 'x' like this: [x] 
-->

- [ ] Screenshot/GIF included (to demonstrate the plugin functionality)

- [x] ToC updated

I am not sure whether a syntax plugin should provide a screenshot or not. However here it is.

![](https://github.com/antfu/wenyan-lang-vscode/raw/master/screenshots/demo-execute.png)