### PR TITLE
Adding GistPad

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ A curated list of delightful [Visual Studio Code](https://code.visualstudio.com/
   - [Error Lens](#error-lens)
   - [ES7 React/Redux/GraphQL/React-Native snippets](#es7-reactreduxgraphqlreact-native-snippets)
   - [Gi](#gi)
+  - [GistPad](#gistpad)
   - [Git History](#git-history)
   - [Git Project Manager](#git-project-manager)
   - [GitLink](#gitlink)
@@ -582,6 +583,12 @@ To enable Emmet support in .twig files, you'll need to have the following in you
 > Generating .gitignore files made easy.
 
 ![.gitignore generation animation](https://raw.githubusercontent.com/hasit/vscode-gi/master/assets/gi.gif)
+
+## [GistPad](https://marketplace.visualstudio.com/items?itemName=vsls-contrib.gistfs)
+
+> Allows you to manage GitHub Gists entirely within the editor. You can open, create, delete, fork, star and clone gists, and then seamlessly begin editing files as if they were local. It's like your very own developer library for building and referencing code snippets, commonly used config/scripts, programming-related notes/documentation, and interactive samples. 
+
+![GistPad gist management](https://user-images.githubusercontent.com/116461/69910156-96274b80-13fe-11ea-9be4-d801f4e9c377.gif)
 
 ## [Git History](https://marketplace.visualstudio.com/items?itemName=donjayamanne.githistory)
 


### PR DESCRIPTION
## Name of the extension you are adding

[GistPad](https://marketplace.visualstudio.com/items?itemName=vsls-contrib.gistfs)

## Why do you think this extension is awesome?

GistPad makes it extremely easy for developers to leverage GitHub Gists as their personal library of code snippets and developer notes. It adds a bunch of helpful features on top of gists, such as allowing you to organize your files into [directories](https://github.com/vsls-contrib/gistpad#files-and-directories), [inline commenting](https://github.com/vsls-contrib/gistpad#gist-commenting), [grouping](https://github.com/vsls-contrib/gistpad#sorting-and-grouping), and the ability to [follow your friends](https://github.com/vsls-contrib/gistpad#following-users).

Additionally, it lets you create [CodePen-like playgrounds](https://twitter.com/LostInTangent/status/1207718123241033728) / [tutorials](https://twitter.com/LostInTangent/status/1228780570932498432), and then visually iterate on your code, entirely within the editor.

## Make sure that:

- [x] Screenshot/GIF included (to demonstrate the plugin functionality)
- [x] ToC updated
