### PR TITLE
Add Groovy category in linters index, and add VsCodeGroovy lint  gif

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ A curated list of delightful [Visual Studio Code](https://code.visualstudio.com/
   - [Clojure](#clojure)
   - [CSS](#css)
   - [Go](#go)
+  - [Groovy](#groovy)
   - [Haskell](#haskell)
   - [Shell](#shell)
   - [Java](#java)
@@ -364,6 +365,12 @@ Unlike some other editors, VS Code supports IntelliSense, linting, outline out-o
 ## Go
 
 - [Go](https://marketplace.visualstudio.com/items?itemName=ms-vscode.Go) - Rich language support for the Go language.
+
+## Groovy
+
+- [VsCode Groovy Lint](https://marketplace.visualstudio.com/items?itemName=NicolasVuillamy.vscode-groovy-lint) - Groovy lint, format, prettify and auto-fix
+
+![VsCode Groovy Lint](https://github.com/nvuillam/vscode-groovy-lint/raw/master/images/vscode-anim.gif)
 
 ## Haskell
 


### PR DESCRIPTION
## Name of the extension you are adding

VsCode Groovy Lint

## Why do you think this extension is awesome?

Because CodeNarc groovy linter is a nice tool but wasn't available for VsCode, and there was also no way to format or automatically fix the errors ... and now there is , we can finally build our shared libraries in VsCode and have a linter, formatter and correcter with a single extension :)

## Make sure that:

<!-- 
Check off the checkboxes with an 'x' like this: [x] 
-->

- [x] Screenshot/GIF included (to demonstrate the plugin functionality)

- [x] ToC updated
