### PR TITLE
Add Git Mob extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ A curated list of delightful [Visual Studio Code](https://code.visualstudio.com/
   - [GitHub](#github)
   - [GitHub Pull Request Monitor](#github-pull-request-monitor)
   - [GitLab Workflow](#gitlab-workflow)
+  - [Git Mob](#git-mob)
   - [Gradle Tasks](#gradle-tasks)
   - [Icon Fonts](#icon-fonts)
   - [Import Cost](#import-cost)
@@ -629,6 +630,11 @@ To enable Emmet support in .twig files, you'll need to have the following in you
 > Adds a GitLab sidebar icon to view issues, merge requests and other GitLab resources.  You can also view the results of your GitLab CI/CD pipeline and check the syntax of your `.gitlab-ci.yml`.
 
 ![GitLab Workflow](https://gitlab.com/fatihacet/gitlab-vscode-extension/raw/master/src/assets/_issues-in-vscode.png)
+
+## [Git Mob](https://marketplace.visualstudio.com/items?itemName=RichardKotze.git-mob)
+> A simple UI to manage people you regularly pair/mob program with to add Github co-author meta data to commits.
+
+![Git Mob in action](https://user-images.githubusercontent.com/10452163/51446144-cc3b6f80-1d05-11e9-87fa-96622a25eedc.gif)
 
 #### [Gradle Tasks](https://marketplace.visualstudio.com/items?itemName=richardwillis.vscode-gradle)
 


### PR DESCRIPTION
## Name of the extension you are adding

Git Mob - Co-authors in commits

## Why do you think this extension is awesome?

Makes life easy for when pair/mob programming to attribute co-authors by adding them to the commit.

## Make sure that:

- [x] Screenshot/GIF included (to demonstrate the plugin functionality)

- [x] ToC updated
