### PR TITLE
Added iTerm2 theme sync 

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ A curated list of delightful [Visual Studio Code](https://code.visualstudio.com/
   - [ftp-sync](#ftp-sync)
   - [Highlight JSX/HTML tags](#highlight-jsxhtml-tags)
   - [Indent Rainbow](#indent-rainbow)
+  - [iTerm2 Theme Sync](#iterm2-theme-sync)
   - [PlatformIO](#platformio)
   - [Polacode](#polacode)
   - [Quokka](#quokka)
@@ -972,6 +973,12 @@ To enable Emmet support in .twig files, you'll need to have the following in you
 > A simple extension to make indentation more readable.
 
 ![indent-rainbow](https://raw.githubusercontent.com/oderwat/vscode-indent-rainbow/master/assets/example.png)
+
+## [iTerm2 Theme Sync](https://marketplace.visualstudio.com/items?itemName=tusaeff.vscode-iterm2-theme-sync)
+
+> Syncs selected VSCode theme with iTerm2 color profile
+
+![iTerm2 Theme Sync](https://raw.githubusercontent.com/tusaeff/vscode-iterm2-theme-sync/master/screencast.gif)
 
 ## [PlatformIO](https://marketplace.visualstudio.com/items?itemName=formulahendry.platformio)
 


### PR DESCRIPTION
## Name of the extension you are adding
[iTerm2 Theme Sync](https://marketplace.visualstudio.com/items?itemName=tusaeff.vscode-iterm2-theme-sync)

## Why do you think this extension is awesome?
How this extension helps me every day:
1. I no longer think about what theme I have chosen in the terminal - now I have one VSCode theme to rule them all.
2. I no longer find myself in a situation where I have a dark theme in the editor and a light theme in the terminal (or vice versa) - now my eyes do not hurt when I switch between them.

I think a lot of people experience similar problems and this extension can help solve them :)

## Make sure that:

- [x] Screenshot/GIF included (to demonstrate the plugin functionality)
- [x] ToC updated
