### PR TITLE
Fix: mattbierner Twitter link typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1373,7 +1373,7 @@ A list of Twitter accounts for various people in the VS Code Community
 - [@johannesrieken](https://twitter.com/johannesrieken) - VS Code Dev
 - [@lannonbr](https://twitter.com/lannonbr) - Creator of vscode.rocks & JS Parameter Annotations extension
 - [@maeschli](https://twitter.com/maeschli) - VS Code Dev
-- [@mattbierner](https://twitter.com/code) - VS Code Dev
+- [@mattbierner](https://twitter.com/mattbierner) - VS Code Dev
 - [@MrAhmadAwais](https://twitter.com/MrAhmadAwais) - JS/WordPress Core Dev. Creator of VSCode.pro course & Shades of Purple theme
 - [@ramyanexus](https://twitter.com/ramyanexus) - VS Code Dev. Maintainer of Go extension
 - [@Tyriar](https://twitter.com/Tyriar) - VS Code Dev. Creator of xterm.js


### PR DESCRIPTION
That's a very tiny change to fix a typo to one of the Contributor's Twitter account.