### PR TITLE
Remove vscode-text-marker duplicated image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1108,8 +1108,6 @@ To enable Emmet support in .twig files, you'll need to have the following in you
 
 ![ESDOC MDN](https://raw.githubusercontent.com/samundrak/vscode-esdoc-mdn/master/demo.gif)
 
-![Interface generator (Typescript)](https://raw.githubusercontent.com/ryu1kn/vscode-text-marker/master/images/animations/public.gif)
-
 ## [Interface generator](https://marketplace.visualstudio.com/items?itemName=dotup.dotup-vscode-interface-generator)
 
 > Quickly generate interface definitions from typescript class


### PR DESCRIPTION
Duplicated image from Text Marker (Highlighter) section

fixes #341
