### PR TITLE
Add `typed-vscode` to libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -1401,6 +1401,7 @@ A list of Twitter accounts for various people in the VS Code Community
 ## Libraries
 
 - [vscode-test-content](https://github.com/mlewand-org/vscode-test-content) - A method to set/get editor content, and it's selection. Especially useful for unit tests.
+- [typed-vscode](https://www.npmjs.com/typed-vscode) - Generates types from contribution points of your extension manifest
 
 ## Tools
 


### PR DESCRIPTION
Hey! Some time ago I've an idea of creating framework for vscode development that would care of adding links, ids, bundling and so on. I've abandoned it, however the library I'm adding isn't part of this ecosystem and its pretty stable and covered with integration tests.

This library improves DX only, it does nothing at runtime

## Why do you think this library is awesome?

Just why not, AFAIK there is no other way to achieve something like that.

## Make sure that:

<!-- 
Check off the checkboxes with an 'x' like this: [x] 
-->

- [ ] Screenshot/GIF included (to demonstrate the plugin functionality)

- [ ] ToC updated
