### PR TITLE
Add Tidy Explorer

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ A curated list of delightful [Visual Studio Code](https://code.visualstudio.com/
   - [Remote VSCode](#remote-vscode)
   - [REST Client](#rest-client)
   - [Text Power Tools](#text-power-tools)
+  - [Tidy Explorer](#tidy-explorer)
   - [Todo Tree](#todo-tree)
   - [Toggle Quotes](#toggle-quotes)
   - [Typescript Destructure](#typescript-destructure)
@@ -860,6 +861,18 @@ Example of toggling `typescript.inlayHints.functionLikeReturnTypes.enabled` by s
 > All-in-one extension for text manipulation: filtering (grep), remove lines, insert number sequences and GUIDs, format content as table, change case, converting numbers and more. Great for finding information in logs and manipulating text.
 
 ![Text Power Tools](https://raw.githubusercontent.com/qcz/vscode-text-power-tools/89a1d9d7be3edfc9bcf112fe427c662655cb60cc/images/filtering.gif)
+
+## [Tidy Explorer](https://marketplace.visualstudio.com/items?itemName=bingtimren.tidy-explorer)
+> Tidy up your file explorer, hide or pin files and folders with just one click.
+
+![Tidy Explorer](https://github.com/bingtimren/vscode-tidy-explorer/raw/HEAD/images/switchboard.png)
+
+This extension allows you to configure glob patterns and group related glob patterns into "Pockets". Then you can toggle the files that match an individual pattern or all patterns in a Pocket to:
+
+- hide the files in the file Explorer (one-click adding into the "files.exclude" setting)
+- pin the files in the "Tidy Explorer"
+
+When you have a complex project with a large number of files and folders, this extension help you reduce the distractions from uninterested files (e.g. auto-generated) and focus on the files you are working on.
 
 ## [Todo Tree](https://marketplace.visualstudio.com/items?itemName=Gruntfuggly.todo-tree)
 


### PR DESCRIPTION
Tidy up your file explorer, hide or pin files and folders with just one click.

This extension allows you to configure glob patterns and group related glob patterns into "Pockets". Then you can toggle the files that match an individual pattern or all patterns in a Pocket to:

hide the files in the file Explorer (one-click adding into the "files.exclude" setting)
pin the files in the "Tidy Explorer"
When you have a complex project with a large number of files and folders, this extension help you reduce the distractions from uninterested files (e.g. auto-generated) and focus on the files you are working on.

See https://marketplace.visualstudio.com/items?itemName=bingtimren.tidy-explorer

## Name of the extension you are adding

Tidy Explorer

## Why do you think this extension is awesome?

When working with a large and complex project, developer often wants to focus on a small set of files at a time, and the rest of the files (configurations, files not being worked on) become a distraction, also makes the files being worked on or of interest difficult to find.

Tidy explorer allows you to category your files (define in "Pockets"), hide or pin them with single click.

## Make sure that:

<!-- 
Check off the checkboxes with an 'x' like this: [x] 
-->

- [X] Screenshot/GIF included (to demonstrate the plugin functionality)

- [X] ToC updated
