### PR TITLE
Fix: Markdown syntax support to static site

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A curated list of delightful <a href="https://code.visualstudio.com/">Visual Stu
 packages and resources. For more awesomeness, check
 out <a href="https://github.com/sindresorhus/awesome">awesome</a>.
 <br/>
+<br/>
 <img src="https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg" alt="Awesome"/>
 <img src="https://travis-ci.org/viatsko/awesome-vscode.svg" alt="Build Status"/>
 </div>

--- a/README.md
+++ b/README.md
@@ -6,9 +6,12 @@
 <br/>
 <div align="center">
 
-A curated list of delightful [Visual Studio Code](https://code.visualstudio.com/) packages and resources. For more awesomeness, check out [awesome](https://github.com/sindresorhus/awesome).
-
-[![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg)](https://github.com/sindresorhus/awesome) [![Build Status](https://travis-ci.org/viatsko/awesome-vscode.svg)](https://travis-ci.org/viatsko/awesome-vscode)
+A curated list of delightful <a href="https://code.visualstudio.com/">Visual Studio Code</a>
+packages and resources. For more awesomeness, check
+out <a href="https://github.com/sindresorhus/awesome">awesome</a>.
+<br/>
+<img src="https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg" alt="Awesome"/>
+<img src="https://travis-ci.org/viatsko/awesome-vscode.svg" alt="Build Status"/>
 </div>
 <br/>
 


### PR DESCRIPTION
## Name of the extension you are adding

Fix project's description and status badge that consist of unsupported syntax on static site. 

## Why do you think this extension is awesome?

...

## Make sure that:

<!-- 
Check off the checkboxes with an 'x' like this: [x] 
-->

- [x] Screenshot/GIF included (to demonstrate the plugin functionality)
![image](https://user-images.githubusercontent.com/4939738/151989015-d96a3a93-d0e7-4965-a0eb-96f1e2d64d6c.png)
![image](https://user-images.githubusercontent.com/4939738/151989035-6288a85c-7197-4ead-b6df-f66226017603.png)

- [ ] ToC updated
