### PR TITLE
Add Document Viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -692,7 +692,7 @@ To enable Emmet support in .twig files, you'll need to have the following in you
 
 > The Document Viewer extension enables developers to seamlessly view Word, Excel, Pdf, Markdown, CSV, and TSV files directly within VS Code. No more switching between applications - keep your workflow uninterrupted by viewing documents in the same environment where you code.
 
-![DocumentViewerExtension](https://cdn.syncfusion.com/visual-studio-market/document-viewer/DocumentViewerHowtoUse.gif)
+![DocumentViewerHowtoUse](https://cdn.syncfusion.com/visual-studio-market/document-viewer/DocumentViewerHowtoUse.gif)
 
 ## [Duplicate Action](https://marketplace.visualstudio.com/items?itemName=mrmlnc.vscode-duplicate)
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ out <a href="https://github.com/sindresorhus/awesome">awesome</a>.
   - [Create tests](#create-tests)
   - [Dendron](#dendron)
   - [Deploy](#deploy)
+  - [Document Viewer](#document-viewer)
   - [Duplicate Action](#duplicate-action)
   - [Error Lens](#error-lens)
   - [Toggle](#toggle)
@@ -686,6 +687,12 @@ To enable Emmet support in .twig files, you'll need to have the following in you
 > Commands for upload or copy files of a workspace to a destination.
 
 ![Upload/copy files animation](https://raw.githubusercontent.com/mkloubert/vs-deploy/master/img/demo.gif)
+
+## [Document Viewer](https://marketplace.visualstudio.com/items?itemName=SyncfusionInc.Document-Viewer-VSCode-Extensions)
+
+> View PDF, Word, Excel, and Markdown files directly in VS Code without external applications.
+
+![DocumentViewerExtension](https://cdn.syncfusion.com/visual-studio-market/document-viewer/DocumentViewerHowtoUse.gif)
 
 ## [Duplicate Action](https://marketplace.visualstudio.com/items?itemName=mrmlnc.vscode-duplicate)
 

--- a/README.md
+++ b/README.md
@@ -690,7 +690,7 @@ To enable Emmet support in .twig files, you'll need to have the following in you
 
 ## [Document Viewer](https://marketplace.visualstudio.com/items?itemName=SyncfusionInc.Document-Viewer-VSCode-Extensions)
 
-> View PDF, Word, Excel, and Markdown files directly in VS Code without external applications.
+> The Document Viewer extension enables developers to seamlessly view Word, Excel, Pdf, Markdown, CSV, and TSV files directly within VS Code. No more switching between applications - keep your workflow uninterrupted by viewing documents in the same environment where you code.
 
 ![DocumentViewerExtension](https://cdn.syncfusion.com/visual-studio-market/document-viewer/DocumentViewerHowtoUse.gif)
 

--- a/README.md
+++ b/README.md
@@ -692,7 +692,7 @@ To enable Emmet support in .twig files, you'll need to have the following in you
 
 > The Document Viewer extension enables developers to seamlessly view Word, Excel, Pdf, Markdown, CSV, and TSV files directly within VS Code. No more switching between applications - keep your workflow uninterrupted by viewing documents in the same environment where you code.
 
-![DocumentViewerHowtoUse](https://cdn.syncfusion.com/visual-studio-market/document-viewer/DocumentViewerHowtoUse.gif)
+![OpenFile](https://raw.githubusercontent.com/syncfusion-content/extension-docs/refs/heads/master/Extension/Document-Viewer-Extension/Visual-Studio-Code/images/OpenFile.gif)
 
 ## [Duplicate Action](https://marketplace.visualstudio.com/items?itemName=mrmlnc.vscode-duplicate)
 


### PR DESCRIPTION
## Name of the extension you are adding

Document Viewer

## Why do you think this extension is awesome?

The Document Viewer extension enables developers to seamlessly view Word, Excel, Pdf, Markdown, CSV, and TSV files directly within VS Code. No more switching between applications - keep your workflow uninterrupted by viewing documents in the same environment where you code.

## Make sure that:

- [x] Screenshot/GIF included (to demonstrate the plugin functionality)

- [x] ToC updated
