### PR TITLE
Add MEO - Markdown editor with live/source toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -503,6 +503,12 @@ With MATLAB installed:
 
 ![Markdown Emoji](https://raw.githubusercontent.com/mjbvz/vscode-markdown-emoji/master/docs/example.png)
 
+### [MEO](https://marketplace.visualstudio.com/items?itemName=vadimmelnicuk.meo)
+
+> A proper Markdown live editing mode for VS Code. Adds a live/source toggle in a single tab, a floating formatting toolbar, inline table editing, full-screen Mermaid diagram rendering, and a document outline sidebar — without leaving VS Code or opening a split pane.
+
+![MEO](https://github.com/vadimmelnicuk/meo/blob/ed165a91abd5338ad940487e59325c3331bec21b/demo.gif?raw=1)
+
 ## PHP
 
 ### [PHP Tools](https://marketplace.visualstudio.com/items?itemName=DEVSENSE.phptools-vscode)

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ out <a href="https://github.com/sindresorhus/awesome">awesome</a>.
     - [markdownlint](#markdownlint)
     - [Markdown All in One](#markdown-all-in-one)
     - [Markdown Emoji](#markdown-emoji)
+    - [MEO](#meo)
   - [PHP](#php)
     - [PHP Tools](#php-tools)
     - [IntelliSense](#intellisense)


### PR DESCRIPTION
## Name of the extension you are adding

MEO

## Why do you think this extension is awesome?

[MEO](https://marketplace.visualstudio.com/items?itemName=vadimmelnicuk.meo) is a Markdown editor extension for VS Code that fills a genuine gap: VS Code's built-in Markdown experience is either raw syntax editing or a read-only preview pane in a split - neither is great for focused writing.

MEO adds:
- Live/source toggle in a single tab (no split pane)
- Floating formatting toolbar
- Inline table editing
- Full-screen Mermaid diagram rendering
- Document outline sidebar
- Preserves VS Code's native diff view - git changes in `.md` files still work

**Placement:** Added under `Lint and IntelliSense > Markdown`, in alphabetical order after `Markdown Emoji`.

**Marketplace:** https://marketplace.visualstudio.com/items?itemName=vadimmelnicuk.meo

**GitHub:** https://github.com/vadimmelnicuk/meo

## Checklist
- [x] Link goes to marketplace.visualstudio.com
- [x] Added to the correct section (Markdown)
- [x] In alphabetical order
- [x] GIF included (to demonstrate the plugin functionality)
- [x] Follows the required format
- [x] ToC updated
