### PR TITLE
Add Skill Dock — local-first agent skill manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -978,6 +978,10 @@ Example of toggling `typescript.inlayHints.functionLikeReturnTypes.enabled` by s
 
 ![Indentation of pasted code animation](https://github.com/vikrantnegi/vscode-personal-preference-setting/blob/master/screenshots/pasteandindent.gif)
 
+## [Skill Dock](https://marketplace.visualstudio.com/items?itemName=skill-dock.skill-dock)
+
+> Local-first agent skill manager for VS Code. Browse, create, and import skills across Claude, Cursor, Copilot, and 20+ AI tools. Includes a marketplace with skills.sh integration.
+
 ## [Sort Lines](https://marketplace.visualstudio.com/items?itemName=Tyriar.sort-lines)
 
 > Sorts lines of text in specific order


### PR DESCRIPTION
## Skill Dock

[VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=skill-dock.skill-dock) | [GitHub](https://github.com/yen0304/Skill-Dock)

Local-first agent skill manager for VS Code / Cursor. Browse, create, edit, and import agent skills across 20+ AI tools including Claude, Cursor, GitHub Copilot, Windsurf, Cline, and more.

**Key features:**
- Full CRUD skill library stored locally (~/.skilldock/skills/)
- Import skills to any repo in 20+ agent formats
- Built-in marketplace with 5 sources + skills.sh ecosystem search
- Multi-language support (en, zh-tw, zh-cn, ja)
- Symlink or copy install modes
- 443 tests, MIT licensed

Added under the **Productivity** section in alphabetical order.