### PR TITLE
Fix broken image and remove dead link

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,0 @@
-language: ruby
-rvm: 2.2
-before_script: gem install awesome_bot
-script: awesome_bot README.md --white-list travis-ci,tslint,code.visualstudio.com,awesome,microsoft.com,viatsko.me,drupal.org,camo.githubusercontent.com --allow 429  --allow-dupe

--- a/README.md
+++ b/README.md
@@ -55,7 +55,6 @@ out <a href="https://github.com/sindresorhus/awesome">awesome</a>.
     - [Debugger for Chrome](#debugger-for-chrome)
     - [Facebook Flow](#facebook-flow)
     - [TypeScript](#typescript)
-    - [Debugger for Chrome](#debugger-for-chrome-1)
   - [MATLAB](#matlab)
   - [Markdown](#markdown)
     - [markdownlint](#markdownlint)
@@ -459,12 +458,6 @@ See the difference between these two [here](https://github.com/michaelgmcd/vscod
 - [vscode-flow-ide](https://marketplace.visualstudio.com/items?itemName=gcazaciuc.vscode-flow-ide) - an alternative Flowtype extension for Visual Studio Code
 
 ### TypeScript
-
-- [tslint (deprecated)](https://marketplace.visualstudio.com/items?itemName=ms-vscode.vscode-typescript-tslint-plugin) - TSLint for Visual Studio Code.
-
-### [Debugger for Chrome](https://marketplace.visualstudio.com/items?itemName=msjsdiag.debugger-for-chrome)
-
-> A VS Code extension to debug your JavaScript code in the Chrome browser, or other targets that support the Chrome Debugging Protocol.
 
 ## [MATLAB](https://marketplace.visualstudio.com/items?itemName=MathWorks.language-matlab)
 > This extension provides support for editing MATLAB® code in Visual Studio® Code and includes features such as syntax highlighting, code analysis, navigation support, and more.

--- a/README.md
+++ b/README.md
@@ -11,8 +11,7 @@ packages and resources. For more awesomeness, check
 out <a href="https://github.com/sindresorhus/awesome">awesome</a>.
 <br/>
 <br/>
-<img src="https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg" alt="Awesome"/>
-<img src="https://travis-ci.org/viatsko/awesome-vscode.svg" alt="Build Status"/>
+<a href="https://github.com/sindresorhus/awesome"><img src="https://cdn.jsdelivr.net/gh/sindresorhus/awesome@d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg" alt="Awesome"/></a>
 </div>
 <br/>
 

--- a/README.md
+++ b/README.md
@@ -902,7 +902,7 @@ Example of toggling `typescript.inlayHints.functionLikeReturnTypes.enabled` by s
 
 > Custom keywords, highlighting, and colors for TODO comments. As well as a sidebar to view all your current tags.
 
-![Todo Tree](https://thumbs.gfycat.com/PowerlessWindyCivet-size_restricted.gif)
+![Todo Tree](https://raw.githubusercontent.com/Gruntfuggly/todo-tree/master/resources/screenshot.png)
 
 ## [Toggle Quotes](https://marketplace.visualstudio.com/items?itemName=BriteSnow.vscode-toggle-quotes)
 
@@ -1456,7 +1456,6 @@ A list of Twitter accounts for various people in the VS Code Community
 ## Tools
 
 - [Live Share](https://marketplace.visualstudio.com/items?itemName=MS-vsliveshare.vsliveshare) - Visual Studio Live Share enables you to collaboratively edit and debug with others in real time, regardless what programming languages you're using or app types you're building.
-- [Online TextMate Themes Editor](https://tmtheme-editor.herokuapp.com/) - since VS Code supports TextMate themes, you can create them in this online editor and then create a new VS Code package using [Yo Code](https://code.visualstudio.com/docs/extensions/yocode) tool
 - [Yo Code - Extension Generator](https://code.visualstudio.com/docs/extensions/yocode)
 - [Open in Code](https://github.com/sozercan/OpenInCode) - macOS Finder toolbar app to open current folder in Visual Studio Code
 


### PR DESCRIPTION
A couple of links in the README point to services that no longer exist:

- The Todo Tree screenshot was hosted on Gfycat, which shut down in September 2023. Replaced it with an image from the extension's own repository.
- The Online TextMate Themes Editor was hosted on Heroku (free tier), which was discontinued in November 2022. Removed the entry since the app is no longer accessible.