### PR TITLE
Remove dead Travis CI config and fix broken badges

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,0 @@
-language: ruby
-rvm: 2.2
-before_script: gem install awesome_bot
-script: awesome_bot README.md --white-list travis-ci,tslint,code.visualstudio.com,awesome,microsoft.com,viatsko.me,drupal.org,camo.githubusercontent.com --allow 429  --allow-dupe

--- a/README.md
+++ b/README.md
@@ -11,8 +11,7 @@ packages and resources. For more awesomeness, check
 out <a href="https://github.com/sindresorhus/awesome">awesome</a>.
 <br/>
 <br/>
-<img src="https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg" alt="Awesome"/>
-<img src="https://travis-ci.org/viatsko/awesome-vscode.svg" alt="Build Status"/>
+<a href="https://github.com/sindresorhus/awesome"><img src="https://cdn.jsdelivr.net/gh/sindresorhus/awesome@d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg" alt="Awesome"/></a>
 </div>
 <br/>
 


### PR DESCRIPTION
Travis CI (travis-ci.org) shut down in 2021, so the build status badge has been broken for a while. The Awesome badge was also served via cdn.rawgit.com which shut down in October 2019.

Changes:
- Removed `.travis.yml` (referenced travis-ci.org and Ruby 2.2, both long dead)
- Replaced cdn.rawgit.com badge URL with cdn.jsdelivr.net (serves the same file)
- Removed the broken Travis CI badge
- Made the Awesome badge clickable