### PR TITLE
Add Kagan to Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ out <a href="https://github.com/sindresorhus/awesome">awesome</a>.
   - [Jira and Bitbucket](#jira-and-bitbucket)
   - [JS Parameter Annotations](#js-parameter-annotations)
   - [Jumpy](#jumpy)
+  - [Kagan](#kagan)
   - [Kanban](#kanban)
   - [Live Server](#live-server)
   - [Multiple clipboards](#multiple-clipboards)
@@ -778,6 +779,12 @@ Example of toggling `typescript.inlayHints.functionLikeReturnTypes.enabled` by s
 > Provides fast cursor movement, inspired by Atom's package of the same name.
 
 ![Jumpy](https://cloud.githubusercontent.com/assets/2899448/19660934/0481c44c-9a32-11e6-87cc-1f8913922ccb.gif)
+
+## [Kagan](https://marketplace.visualstudio.com/items?itemName=kagan.kagan-vscode)
+
+> AI-powered Kanban board for orchestrating coding agents in VS Code. Manage tasks, stream agent output, review diffs, and merge without leaving the editor.
+
+![Kagan](https://raw.githubusercontent.com/kagan-sh/kagan/main/.github/assets/demo.png)
 
 ## [Kanban](https://marketplace.visualstudio.com/items?itemName=mkloubert.vscode-kanban)
 


### PR DESCRIPTION
## Name of the extension you are adding

Kagan

## Why do you think this extension is awesome?

Kagan turns VS Code into an AI orchestration workspace: a Kanban board for coding tasks, a chat participant for agent follow-ups, live task output streaming, diff review, and merge flows without leaving the editor.

It is especially useful for developers already using coding agents and wanting task tracking plus execution/review in one place.

### Additional resource links

- Marketplace: https://marketplace.visualstudio.com/items?itemName=kagan.kagan-vscode
- Open VSX: https://open-vsx.org/extension/kagan/kagan-vscode
- GitHub: https://github.com/kagan-sh/kagan
- Docs: https://docs.kagan.sh/guides/vscode-extension/

## Make sure that:

- [x] Screenshot/GIF included (to demonstrate the plugin functionality)
- [x] ToC updated