### PR TITLE
Add Lateralus Language extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,7 @@ Language packages extend the editor with syntax highlighting and/or snippets for
 - [KL](https://marketplace.visualstudio.com/items?itemName=melmass.kl)
 - [Kotlin](https://marketplace.visualstudio.com/items?itemName=mathiasfrohlich.Kotlin)
 - [LaTeX](https://marketplace.visualstudio.com/items?itemName=torn4dom4n.latex-support)
+- [Lateralus](https://marketplace.visualstudio.com/items?itemName=lateralus.lateralus-lang) - Pipeline-native language with full LSP, syntax highlighting for 7 file types, 50+ snippets, and 15 custom file icons
 - [MATLAB](https://marketplace.visualstudio.com/items?itemName=MathWorks.language-matlab)
 - [Mason](https://marketplace.visualstudio.com/items?itemName=viatsko.html-mason)
 - [openHAB](https://marketplace.visualstudio.com/items?itemName=openhab.openhab)


### PR DESCRIPTION
## Lateralus Language

Adds the [Lateralus Language](https://marketplace.visualstudio.com/items?itemName=lateralus.lateralus-lang) extension to the Syntax section.

**Lateralus** is a pipeline-native programming language with a VM, C backend, and bare-metal OS support. The VS Code extension provides:

- Full LSP with 14 providers (completions, hover, go-to-definition, find references, formatting, code actions, signature help, document/workspace symbols, rename, folding)
- Syntax highlighting for 7 file types (.ltl, .ltasm, .ltlm, .ltlcfg, .ltlnb, .ltbc, .ltlc)
- 50+ code snippets
- 15 custom file icons (light + dark)
- Status bar with LSP server state

**Marketplace**: https://marketplace.visualstudio.com/items?itemName=lateralus.lateralus-lang
**Repository**: https://github.com/bad-antics/lateralus-lang