### PR TITLE
Add VS Code Extension Guide AI skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -1466,6 +1466,7 @@ A list of Twitter accounts for various people in the VS Code Community
 - [Live Share](https://marketplace.visualstudio.com/items?itemName=MS-vsliveshare.vsliveshare) - Visual Studio Live Share enables you to collaboratively edit and debug with others in real time, regardless what programming languages you're using or app types you're building.
 - [Online TextMate Themes Editor](https://tmtheme-editor.herokuapp.com/) - since VS Code supports TextMate themes, you can create them in this online editor and then create a new VS Code package using [Yo Code](https://code.visualstudio.com/docs/extensions/yocode) tool
 - [Yo Code - Extension Generator](https://code.visualstudio.com/docs/extensions/yocode)
+- [VS Code Extension Guide (AI Skill)](https://github.com/lewiswigmore/agent-skills/tree/main/skills/vscode-extension-guide-en) - An installable AI agent skill covering extension development from scaffolding to Marketplace publication. Covers webview patterns, TreeView, testing and packaging for VS Code 1.74+.
 - [Open in Code](https://github.com/sozercan/OpenInCode) - macOS Finder toolbar app to open current folder in Visual Studio Code
 
 ![macOS Finder toolbar app to open current folder in Visual Studio Code animation](https://camo.githubusercontent.com/edbae5fe27d6c7af23218e60cb07e3a5061bbbab/687474703a2f2f692e696d6775722e636f6d2f4c6d56484978572e676966)


### PR DESCRIPTION
Adds a link to the VS Code Extension Guide AI skill under Resources > Tools.

This is an installable agent skill (via skills.sh) that covers extension development from scaffolding through to Marketplace publication. It includes reference material on webview patterns, TreeView, testing and packaging, updated for VS Code 1.74+ APIs.

Based on aktsmm/agent-skills (CC BY-NC-SA 4.0), translated to English and updated where the VS Code extension docs have changed.

Link: https://github.com/lewiswigmore/agent-skills/tree/main/skills/vscode-extension-guide-en
