### PR TITLE
Add Workspai

### DIFF
--- a/README.md
+++ b/README.md
@@ -928,6 +928,12 @@ Example of toggling `typescript.inlayHints.functionLikeReturnTypes.enabled` by s
 
 > Automatic time tracker and productivity dashboard showing how long you coded in each project, file, branch, and language.
 
+## [Workspai](https://marketplace.visualstudio.com/items?itemName=rapidkit.rapidkit-vscode)
+
+> AI workspace for backend teams. Build backend systems with an AI that knows your workspace — dashboard, AI workspace builder, context-aware debugging powered by GitHub Copilot, 27+ modules, and clean architecture. Supports FastAPI, NestJS, Spring Boot, Go/Fiber, Go/Gin.
+
+![Workspai](https://raw.githubusercontent.com/getrapidkit/rapidkit-vscode/main/media/screenshots/workspai-screenshot-1.png)
+
 ## [Yo](https://marketplace.visualstudio.com/items?itemName=samverschueren.yo)
 
 > Scaffold projects using [Yeoman](https://yeoman.io/)


### PR DESCRIPTION
## Name of the extension you are adding

Workspai (by RapidKit)

## Why do you think this extension is awesome?

Workspai is an AI workspace for backend teams built on top of GitHub Copilot. Unlike generic AI tools, it has full context of your workspace — so it can scaffold projects, generate modules, run diagnostics, and debug with awareness of your architecture. It supports FastAPI, NestJS, Spring Boot, Go/Fiber, and Go/Gin with 27+ production-ready modules (auth, database, cache, payments, etc.) and clean architecture defaults. The workspace dashboard gives a full overview of all services in a monorepo-style layout.

## Make sure that:

- [x] Screenshot/GIF included (to demonstrate the plugin functionality)

- [ ] ToC updated