### PR TITLE
Add 'Snappy Link' extension to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ out <a href="https://github.com/sindresorhus/awesome">awesome</a>.
   - [Remote Development](#remote-development)
   - [Remote VSCode](#remote-vscode)
   - [REST Client](#rest-client)
+  - [Snappy Link](#snappy-link)
   - [Text Power Tools](#text-power-tools)
   - [Todo Tree](#todo-tree)
   - [Toggle Quotes](#toggle-quotes)
@@ -899,6 +900,10 @@ Example of toggling `typescript.inlayHints.functionLikeReturnTypes.enabled` by s
 > Allows you to send HTTP request and view the response in Visual Studio Code directly.
 
 ![Send HTTP request and view response animation](https://raw.githubusercontent.com/Huachao/vscode-restclient/master/images/usage.gif)
+
+## [Snappy Link](https://marketplace.visualstudio.com/items?itemName=DenisMal.snappy-link)
+
+> Instantly package, encrypt (AES-256), and share your workspace via a single URL.
 
 ## [Text Power Tools](https://marketplace.visualstudio.com/items?itemName=qcz.text-power-tools)
 


### PR DESCRIPTION
Added 'Snappy Link' section to README with description.

## Name of the extension you are adding

Snappy Link

## Why do you think this extension is awesome?

It solves the common and annoying pain of sharing code. Instead of manually deleting `node_modules` or `.env` files and zipping folders to share a project state, this extension packages the workspace, encrypts it locally (AES-256-GCM), and generates a shareable link in one click. 

Opening the link on the receiving end auto-extracts the project and prompts the user to install dependencies. It heavily optimizes the developer workflow for mentoring, debugging, and collaboration without relying on third-party cloud drives.

## Make sure that:

- [x] Screenshot/GIF included (to demonstrate the plugin functionality)

- [x] ToC updated