### PR TITLE
Add Pronounce (tech-word pronunciation) to Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -879,6 +879,10 @@ Example of toggling `typescript.inlayHints.functionLikeReturnTypes.enabled` by s
 
 ![Project Dashboard](https://user-images.githubusercontent.com/5564731/79053450-b7663700-7c3d-11ea-8498-bbfe7723b47f.gif)
 
+## [Pronounce](https://marketplace.visualstudio.com/items?itemName=sayit.pronounce)
+
+> Hover any tech word — kubectl, nginx, YAML, Ghostty — to hear how it's actually pronounced, with IPA and a cited source. A community dictionary of 1200+ developer and product names; UI localized to English and Simplified Chinese.
+
 ## [Rainbow CSV](https://marketplace.visualstudio.com/items?itemName=mechatroner.rainbow-csv)
 > Highlight columns in comma, tab, semicolon and pipe separated files, consistency check and linting with CSVLint, multi-cursor column editing, column trimming and realignment, and SQL-style querying with RBQL.
 


### PR DESCRIPTION
Adds [Pronounce](https://marketplace.visualstudio.com/items?itemName=sayit.pronounce) under **Productivity**.

It hovers any tech word (kubectl, nginx, YAML, Ghostty, …) and plays how it's actually pronounced, with IPA and a cited source — a community dictionary of 1200+ developer/product names. Open source (MIT), cross-platform, and the UI is localized to English + Simplified Chinese.

- Marketplace: https://marketplace.visualstudio.com/items?itemName=sayit.pronounce
- Repo: https://github.com/anzy-renlab-ai/pronounce

Placed alphabetically in the Productivity section. Thanks for maintaining the list!