### PR TITLE
Add Perl (perl-lsp) to Programming Languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,7 @@ Language packages extend the editor with syntax highlighting and/or snippets for
 - [openHAB](https://marketplace.visualstudio.com/items?itemName=openhab.openhab)
 - [Parser 3](https://marketplace.visualstudio.com/items?itemName=viatsko.parser3)
 - [Pascal](https://marketplace.visualstudio.com/items?itemName=alefragnani.pascal), or [OmniPascal](https://marketplace.visualstudio.com/items?itemName=Wosi.omnipascal) (only for Windows)
+- [Perl (perl-lsp)](https://marketplace.visualstudio.com/items?itemName=tree-sitter-perl.vscode-perl-lsp)
 - [Perl HTML-Template](https://marketplace.visualstudio.com/items?itemName=viatsko.perl-html-template)
 - [POV-Ray](https://marketplace.visualstudio.com/items?itemName=jmaxwilson.vscode-povray)
 - [Protobuf](https://marketplace.visualstudio.com/items?itemName=peterj.proto)


### PR DESCRIPTION
Adds the [Perl (perl-lsp)](https://marketplace.visualstudio.com/items?itemName=tree-sitter-perl.vscode-perl-lsp) extension under Programming Languages, placed alphabetically by Perl.

It's a full Perl language server (type inference, cross-file navigation, framework intelligence for Moo/Moose, Mojolicious, DBIx::Class) built on tree-sitter-perl. The list currently only has the niche "Perl HTML-Template" entry — no general Perl language extension.