### PR TITLE
Add Explicode extension to Uncategorized

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ out <a href="https://github.com/sindresorhus/awesome">awesome</a>.
   - [Dash](#dash)
   - [Edit with Shell Command](#edit-with-shell-command)
   - [Editor Config for VS Code](#editor-config-for-vs-code)
+  - [Explicode](#explicode)
   - [SFTP](#sftp)
   - [Highlight JSX/HTML tags](#highlight-jsxhtml-tags)
   - [Indent Rainbow](#indent-rainbow)
@@ -1052,6 +1053,11 @@ Example of toggling `typescript.inlayHints.functionLikeReturnTypes.enabled` by s
 ## [Editor Config for VS Code](https://marketplace.visualstudio.com/items?itemName=EditorConfig.EditorConfig)
 
 > Editor Config for VS Code
+
+## [Explicode](https://marketplace.visualstudio.com/items?itemName=Explicode.explicode)
+> Turn your scripts into readable docs — a modern take on literate programming.
+
+![Explicode demo](https://raw.githubusercontent.com/benatfroemming/explicode/master/media/demo.gif)
 
 ## [SFTP](https://marketplace.visualstudio.com/items?itemName=Natizyskunk.sftp)
 


### PR DESCRIPTION
Add Explicode to the Uncategorized section, a VS Code extension that turns scripts into readable docs, a modern approach to literate programming.

## Name of the extension you are adding

Explicode

## Why do you think this extension is awesome?

Here are some reasons why I think this package is awesome:
- Write Markdown docs directly inside code comments, no separate files needed
- Live side-by-side preview panel that updates as you type
- Docs stay close to code and are automatically versioned with Git
- Export to Markdown or HTML with one click
- Supports 15+ languages including Python, JavaScript, Rust, Go, and more
- Zero config, no special compilers or build steps required
- Supports images, interlinking, mermaid, and katex

## Make sure that:

<!-- 
Check off the checkboxes with an 'x' like this: [x] 
-->

- [x] Screenshot/GIF included (to demonstrate the plugin functionality)

- [x] ToC updated
